### PR TITLE
Support for mongo+srv

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -187,7 +187,7 @@ pyasn1-modules==0.3.0
     # via oauth2client
 pycparser==2.21
     # via cffi
-pymongo==3.11.4
+pymongo[srv]==3.11.4
     # via
     #   eve
     #   mongolock


### PR DESCRIPTION
The SRV string has a DNS seed list and this particular module extras e.g. **Mongo Atlas** cloud needs it.