### PR TITLE
[SDANSA-567] - Make Send to the default tab in the Publishing pane

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -316,3 +316,8 @@ PRIORITY_TO_PROFILE_MAPPING = {
 }
 
 HEADLINE_MAXLENGTH = 90
+
+# AUTHORING CONFIG
+
+# set send_to tab as the default opened tab in authoring actions
+AUTHORING_ACTIONS_DEFAULT_TAB = "send_to"


### PR DESCRIPTION
This PR sets AUTHORING_ACTIONS_DEFAULT_TAB to "send_to" to make Send to the default tab

Resolves: [SDANSA-567](https://sofab.atlassian.net/browse/SDANSA-567)

[SDANSA-567]: https://sofab.atlassian.net/browse/SDANSA-567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ