### PR TITLE
[SDANSA-576] Enable seconds in publish schedule config

### DIFF
--- a/client/superdesk.config.js
+++ b/client/superdesk.config.js
@@ -43,6 +43,11 @@ module.exports = function() {
             preview: {
                 hideContentLabels: true,
             },
+            panels: {
+                publish: {
+                    allowSeconds: true,
+                },
+            },
         },
 
         language: 'it',


### PR DESCRIPTION
This PR uses the new `authoring.panels.publish.allowSeconds` config to show the seconds in the date picker in the authoring panel for both embargo and publish schedule.

Related to this [PR](https://github.com/superdesk/superdesk-client-core/pull/5133) 