### PR TITLE
Fix broken thumbnail for the Auto publishing widget

### DIFF
--- a/client/ansa/widgets/index.js
+++ b/client/ansa/widgets/index.js
@@ -34,7 +34,7 @@ export default angular.module('ansa.widgets', [])
             sizey: 1,
             template: 'stages-auto-publish.html',
             description: 'Configure auto publishing',
-            thumbnail: require('./thumbnail.svg'),
+            thumbnail: require('./thumbnail.svg').default,
         });
     }])
     .run(['$templateCache', ($templateCache) => {


### PR DESCRIPTION
Tested and the thumbnail is there, both in the grid and in the add widget modal

Fixes [SDANSA-583](https://sofab.atlassian.net/browse/SDANSA-583)

[SDANSA-583]: https://sofab.atlassian.net/browse/SDANSA-583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ