### PR TITLE
SDANSA-585-DateCreated-not-formatted-properly

### DIFF
--- a/client/extensions/ansaIptc/src/extension.ts
+++ b/client/extensions/ansaIptc/src/extension.ts
@@ -2,21 +2,21 @@ import {IExtension, IExtensionActivationResult, ISuperdesk, IArticle, ISubject, 
 
 const PHOTO_CATEGORIES_ID = 'PhotoCategories';
 
-// convert 20191209 to 2019-12-09
-const parseDate = (date: string) => date.length === 8 ?
-    [
-        date.substr(0, 4),
-        date.substr(4, 2),
-        date.substr(6, 2),
-    ].join('-') : date;
+// convert 20191209 or 2019:12:09 to 2019-12-09
+const parseDate = (date: string) => {
+    if (date.length === 8) {
+        return [date.substr(0, 4), date.substr(4, 2), date.substr(6, 2)].join('-');
+    }
+    return date.replace(/:/g, '-');
+};
 
-// convert 152339+0000 to 15:23:39+0000
-const parseTime = (time: string) => time.length >= 6 ?
-    [
-        time.substr(0, 2),
-        time.substr(2, 2),
-        time.substr(4),
-    ].join(':') : time;
+// convert 152339+0000 or 15:23:39+01:00 to 15:23:39+0100
+const parseTime = (time: string) => {
+    if (time.includes(':')) {
+        return time.replace(/([+-]\d{2}):(\d{2})$/, '$1$2');
+    }
+    return [time.substr(0, 2), time.substr(2, 2), time.substr(4)].join(':');
+};
 
 const parseDatetime = (date?: string, time?: string) => (date && time) ?
     `${parseDate(date)}T${parseTime(time)}` :

--- a/client/extensions/ansaIptc/src/extension.ts
+++ b/client/extensions/ansaIptc/src/extension.ts
@@ -11,8 +11,9 @@ const parseDate = (date: string) => {
 };
 
 // convert 152339+0000 or 15:23:39+01:00 to 15:23:39+0100
+// handles: 152339+0000 (compact) and 15:23:39+01:00 (extended)
 const parseTime = (time: string) => {
-    if (time.includes(':')) {
+    if (/^\d{2}:\d{2}(?::\d{2})?/.test(time)) {
         return time.replace(/([+-]\d{2}):(\d{2})$/, '$1$2');
     }
     if (/^\d{6}(?:[+-]\d{4})?$/.test(time)) {

--- a/client/extensions/ansaIptc/src/extension.ts
+++ b/client/extensions/ansaIptc/src/extension.ts
@@ -15,7 +15,10 @@ const parseTime = (time: string) => {
     if (time.includes(':')) {
         return time.replace(/([+-]\d{2}):(\d{2})$/, '$1$2');
     }
-    return [time.substr(0, 2), time.substr(2, 2), time.substr(4)].join(':');
+    if (/^\d{6}(?:[+-]\d{4})?$/.test(time)) {
+        return [time.substr(0, 2), time.substr(2, 2), time.substr(4)].join(':');
+    }
+    return time;
 };
 
 const parseDatetime = (date?: string, time?: string) => (date && time) ?


### PR DESCRIPTION
## Summary

Fixes a bug where `extra.DateCreated` on uploaded images ended up as a malformed string like `"2026:01:30T11::5:9:59+01:00"`.

## Problem

The client-side IPTC mapping in the `ansaIptc` extension had `parseDate` and `parseTime` helpers that only supported the compact IPTC format (e.g. `20260130`, `115959+0100`), while the image metadata has information like this:
```
Date Created : 2026:01:30
Time Created : 11:59:59+01:00
```

When the browser's IPTC reader returned extended-format values (e.g. `2026:01:30`, `11:59:59+01:00`):

- `parseDate` fell through unchanged (length check failed), leaving colons in place.
- `parseTime` still ran `substr` at compact-format offsets, producing bad output like `11::5:9:59+01:00`.

Result: a malformed datetime string was written into `item.extra.DateCreated`, which also propagated to the VFS metadata update and downstream NewsML G2 output.

## Changes

In `client/extensions/ansaIptc/src/extension.ts`:

- **`parseDate`** — in addition to the compact 8-digit case, replace colons with hyphens so `2026:01:30` becomes `2026-01-30`.
- **`parseTime`** — detect already-colon-separated input and pass it through, stripping the colon from the timezone offset so `11:59:59+01:00` becomes `11:59:59+0100` (keeps timezone offset consistent with the format produced by the compact branch).

Fixes [SDANSA-585](https://sofab.atlassian.net/browse/SDANSA-585)


[SDANSA-585]: https://sofab.atlassian.net/browse/SDANSA-585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ