### PR TITLE
Fixing toolbar line counter not updating

### DIFF
--- a/client/extensions/lineCountInAuthoringHeader/src/line-count-toolbar-widget.tsx
+++ b/client/extensions/lineCountInAuthoringHeader/src/line-count-toolbar-widget.tsx
@@ -5,16 +5,122 @@ import {IArticle, ISuperdesk} from 'superdesk-api';
 export function getLineCountToolbarWidget(superdesk: ISuperdesk) {
     const {gettext, gettextPlural} = superdesk.localization;
     const {getLinesCount, stripHtmlTags} = superdesk.utilities;
+    const ATTACH_RETRY_MS = 250;
+    const MAX_ATTACH_ATTEMPTS = 20;
 
-    return class LineCountToolbarWidget extends React.PureComponent<{entity: IArticle}> {
-        render() {
-            const {entity} = this.props;
+    return class LineCountToolbarWidget extends React.PureComponent<
+        {entity: IArticle},
+        {linesCount: number | null}
+    > {
+        private observer: MutationObserver | null = null;
+        private editorEl: HTMLElement | null = null;
+        private attachTimer: number | null = null;
+        private attachAttempts = 0;
+        private frameId: number | null = null;
 
-            if (entity.body_html == null) {
-                return null;
+        constructor(props: {entity: IArticle}) {
+            super(props);
+            this.state = {linesCount: computeFromEntity(props.entity)};
+        }
+
+        componentDidMount() {
+            this.tryAttachObserver();
+        }
+
+        componentDidUpdate(prevProps: {entity: IArticle}) {
+            if (prevProps.entity === this.props.entity) {
+                return;
             }
 
-            const linesCount = getLinesCount(stripHtmlTags(entity.body_html));
+            const currentEl = document.getElementById('bodyhtml');
+
+            if (currentEl !== this.editorEl) {
+                this.teardownObserver();
+                this.tryAttachObserver();
+            }
+
+            if (this.editorEl == null) {
+                const next = computeFromEntity(this.props.entity);
+                if (next !== this.state.linesCount) {
+                    this.setState({linesCount: next});
+                }
+            }
+        }
+
+        componentWillUnmount() {
+            this.teardownObserver();
+        }
+
+        private teardownObserver = () => {
+            this.observer?.disconnect();
+            this.observer = null;
+            this.editorEl = null;
+            this.attachAttempts = 0;
+            if (this.attachTimer != null) {
+                window.clearTimeout(this.attachTimer);
+                this.attachTimer = null;
+            }
+            if (this.frameId != null) {
+                window.cancelAnimationFrame(this.frameId);
+                this.frameId = null;
+            }
+        };
+
+        private tryAttachObserver = () => {
+            const el = document.getElementById('bodyhtml');
+
+            if (el == null) {
+                if (this.attachAttempts >= MAX_ATTACH_ATTEMPTS) {
+                    this.attachTimer = null;
+                    return;
+                }
+                this.attachAttempts += 1;
+                this.attachTimer = window.setTimeout(this.tryAttachObserver, ATTACH_RETRY_MS);
+                return;
+            }
+
+            this.attachTimer = null;
+            this.attachAttempts = 0;
+            this.editorEl = el;
+            this.observer?.disconnect();
+            this.observer = new MutationObserver(this.scheduleRecompute);
+            this.observer.observe(el, {
+                characterData: true,
+                subtree: true,
+                childList: true,
+            });
+            this.recompute();
+        };
+
+        private scheduleRecompute = () => {
+            if (this.frameId != null) {
+                return;
+            }
+
+            this.frameId = window.requestAnimationFrame(() => {
+                this.frameId = null;
+                this.recompute();
+            });
+        };
+
+        private recompute = () => {
+            if (this.editorEl == null) {
+                return;
+            }
+
+            const blocks = this.editorEl.querySelectorAll('[data-block="true"]');
+            const plainText = Array.from(blocks)
+                .map((block) => block.textContent ?? '')
+                .join('\n');
+            const next = getLinesCount(plainText);
+
+            if (next !== this.state.linesCount) {
+                this.setState({linesCount: next});
+            }
+        };
+
+        render() {
+            const {linesCount} = this.state;
 
             if (linesCount == null) {
                 return null;
@@ -28,5 +134,19 @@ export function getLineCountToolbarWidget(superdesk: ISuperdesk) {
                 </dl>
             );
         }
+    };
+
+    function computeFromEntity(entity: IArticle): number | null {
+        const blocks = entity.fields_meta?.body_html?.draftjsState?.[0]?.blocks;
+
+        if (blocks != null) {
+            return getLinesCount(blocks.map((b: {text: string}) => b.text).join('\n'));
+        }
+
+        if (entity.body_html != null) {
+            return getLinesCount(stripHtmlTags(entity.body_html));
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Summary

The line count in the authoring toolbar was stuck on the value from when the article was loaded and never updated while the user typed.

**Root cause:** the widget rendered from `entity.body_html`, which is only updated on save. During editing the prop stays stale, so `getLinesCount(stripHtmlTags(entity.body_html))` always returned the saved value.

**Fix:** observe the live editor DOM and recompute on mutation, with a safe fallback when the editor is not yet (or no longer) present.

## Changes

- Converted `LineCountToolbarWidget` from a stateless render to a stateful `PureComponent<{entity}, {linesCount}>`.
- On mount, locate `#bodyhtml` and attach a `MutationObserver` (`characterData`, `subtree`, `childList`). Recomputes are coalesced with `requestAnimationFrame` to avoid thrashing during fast typing.
- Line count is computed from the editor's Draft.js blocks (`[data-block="true"]` → `textContent`, joined by `\n`).
- `computeFromEntity` provides the initial/fallback value: prefers `entity.fields_meta.body_html.draftjsState[0].blocks`, falls back to `stripHtmlTags(entity.body_html)`.
- Attachment retry is capped at `MAX_ATTACH_ATTEMPTS = 20` (~5s at `ATTACH_RETRY_MS = 250`) so the widget doesn't poll forever in contexts without the editor.
- On `entity` prop change, if `#bodyhtml` was replaced (or the widget never attached), the observer is torn down and re-attached; otherwise the entity-derived count is refreshed as a fallback. Handles article switches where the editor DOM node is recreated.
- Full cleanup (`observer`, `attachTimer`, `frameId`) centralized in `teardownObserver`, called from both `componentWillUnmount` and the re-attach path.

Fixes [SDANSA-584](https://sofab.atlassian.net/browse/SDANSA-584)


[SDANSA-584]: https://sofab.atlassian.net/browse/SDANSA-584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ