### PR TITLE
Remove Semantics call in the Related widget

### DIFF
--- a/client/ansa/AnsaRelatedCtrl.js
+++ b/client/ansa/AnsaRelatedCtrl.js
@@ -1,5 +1,3 @@
-import {isEmpty} from 'lodash';
-import { refreshAnalysis } from '.';
 // duplicated in extensions/imageShortcuts/src/get-widgets.tsx
 // constants aren't used to avoid imports between multiple projects
 const featureMediaField = 'feature_media';
@@ -12,137 +10,100 @@ const getQueryTimeZone = () => {
     return now.getTimezoneOffset() === -120 ? '+02:00' : '+01:00';
 };
 
-AnsaRelatedCtrl.$inject = ['$scope', 'api', '$rootScope', 'storage', 'Keys'];
-export default function AnsaRelatedCtrl($scope, api, $rootScope, storage, Keys) {
-    refreshAnalysis($scope, api, $rootScope, false).then(() => {
-        const search = () => {
-            this.items = null;
-            let semantics = $scope.item.semantics || {};
+AnsaRelatedCtrl.$inject = ['$scope', 'api', 'storage', 'Keys'];
+export default function AnsaRelatedCtrl($scope, api, storage, Keys) {
+    const search = () => {
+        if (!this.query) {
+            this.items = [];
+            this.searched = false;
+            return;
+        }
 
-            if (isEmpty(semantics.iptcCodes) && isEmpty(semantics.persons)
-                && isEmpty(semantics.organisations) && !this.query) {
-                this.items = [];
-                return;
-            }
+        this.items = null;
+        this.searched = true;
 
-            let filters = [];
-            let keys = ['persons', 'organizations'];
-            let namespace = (key) => 'semantics.' + key;
-
-            keys.forEach((key) => {
-                if (semantics[key] && semantics[key].length) {
-                    semantics[key].forEach((val) => {
-                        let f = {};
-
-                        f[namespace(key)] = val;
-
-                        if (key === 'persons') {
-                            filters.push({match: {[namespace(key)]: {query: val, operator: 'and'}}});
-                        } else {
-                            filters.push({match_phrase: f});
-                        }
-                    });
-                }
-            });
-
-            let query = {
-                bool: {
-                    must: [{term: {type: this.activeFilter}}],
-                    should: filters,
-                    must_not: [{term: {item_id: $scope.item._id}}],
-                    minimum_should_match: window.MINIMUM_SHOULD_MATCH || 1,
-                },
-            };
-
-            if (!isEmpty(semantics.iptcCodes) && this.activeFilter === 'text') {
-                query.bool.must.push({terms: {'semantics.iptcCodes': semantics.iptcCodes}});
-            }
-
-            if (this.query) {
-                query = {
-                    bool: {
-                        must: [
-                            {term: {type: this.activeFilter}},
-                            {query_string: {query: this.query, lenient: true, default_operator: 'AND'}},
-                        ],
-                        must_not: [{term: {item_id: $scope.item._id}}],
-                    },
-                };
-            }
-
-            // filter out older versions
-            query.bool.must.push(
-                {term: {state: 'published'}}
-            );
-
-            // and rewritten versions
-            query.bool.must_not.push(
-                {exists: {field: 'rewritten_by'}}
-            );
-
-            // filter out afp
-            query.bool.must_not.push({term: {creditline: 'AFP'}});
-
-            // filter out used
-            query.bool.must_not.push({range: {used_updated: {gte: 'now/d', time_zone: getQueryTimeZone()}}});
-
-            console.info('query', angular.toJson(query, 2));
-
-            this.apiQuery(query);
+        const query = {
+            bool: {
+                must: [
+                    {term: {type: this.activeFilter}},
+                    {query_string: {query: this.query, lenient: true, default_operator: 'AND'}},
+                ],
+                must_not: [{term: {item_id: $scope.item._id}}],
+            },
         };
 
-        this.activeFilter = storage.getItem('ansa.related.filter') || 'text';
+        // filter out older versions
+        query.bool.must.push(
+            {term: {state: 'published'}}
+        );
 
-        this.filter = (activeFilter) => {
-            this.activeFilter = activeFilter;
-            storage.setItem('ansa.related.filter', activeFilter);
-            search();
-        };
+        // and rewritten versions
+        query.bool.must_not.push(
+            {exists: {field: 'rewritten_by'}}
+        );
 
-        this.searchOnEnter = (event) => {
-            if (event.which === Keys.enter) {
-                search();
-            }
-        };
+        // filter out afp
+        query.bool.must_not.push({term: {creditline: 'AFP'}});
 
-        this.apiQuery = (query) => api.query('news', {source: {
-            query: query,
-            sort: [{versioncreated: 'desc'}],
-            size: 50,
-        }})
-            .then((response) => {
-                this.items = response._items.map((published) => Object.assign(
-                    {},
-                    published.archive_item || published,
-                    {_type: published.archive_item ? 'archive' : 'published'},
-                ));
-            }, (reason) => {
-                this.items = [];
-            });
+        // filter out used
+        query.bool.must_not.push({range: {used_updated: {gte: 'now/d', time_zone: getQueryTimeZone()}}});
 
+        console.info('query', angular.toJson(query, 2));
+
+        this.apiQuery(query);
+    };
+
+    this.items = [];
+    this.searched = false;
+    this.activeFilter = storage.getItem('ansa.related.filter') || 'text';
+
+    this.filter = (activeFilter) => {
+        this.activeFilter = activeFilter;
+        storage.setItem('ansa.related.filter', activeFilter);
         search();
+    };
 
-        // set given picture as featured for current item
-        this.setFeatured = (picture) => {
-            window['__private_ansa__add_image_to_article'](featureMediaField, picture);
-        };
+    this.searchOnEnter = (event) => {
+        if (event.which === Keys.enter) {
+            search();
+        }
+    };
 
-        // add picture to item photo gallery
-        this.addToGallery = (picture) => {
-            window['__private_ansa__add_image_to_article'](galleryField, picture);
-        };
-
-        this.allowAddMedia = () => $scope._editable && $scope.item.type === 'text';
-
-        $scope.featureMediaField = featureMediaField;
-        $scope.galleryField = galleryField;
-
-        $scope.$watch('item', (item) => {
-            if (item != null) {
-                $scope.contentProfile = window['__private_ansa__get_content_profile'](item.profile) || null;
-            } else {
-                $scope.contentProfile = null;
-            }
+    this.apiQuery = (query) => api.query('news', {source: {
+        query: query,
+        sort: [{versioncreated: 'desc'}],
+        size: 50,
+    }})
+        .then((response) => {
+            this.items = response._items.map((published) => Object.assign(
+                {},
+                published.archive_item || published,
+                {_type: published.archive_item ? 'archive' : 'published'},
+            ));
+        }, (reason) => {
+            this.items = [];
         });
+
+    // set given picture as featured for current item
+    this.setFeatured = (picture) => {
+        window['__private_ansa__add_image_to_article'](featureMediaField, picture);
+    };
+
+    // add picture to item photo gallery
+    this.addToGallery = (picture) => {
+        window['__private_ansa__add_image_to_article'](galleryField, picture);
+    };
+
+    this.allowAddMedia = () => $scope._editable && $scope.item.type === 'text';
+
+    $scope.featureMediaField = featureMediaField;
+    $scope.galleryField = galleryField;
+
+    $scope.$watch('item', (item) => {
+        if (item != null) {
+            $scope.contentProfile = window['__private_ansa__get_content_profile'](item.profile) || null;
+        } else {
+            $scope.contentProfile = null;
+        }
     });
 }

--- a/client/ansa/AnsaRelatedCtrl.js
+++ b/client/ansa/AnsaRelatedCtrl.js
@@ -13,7 +13,9 @@ const getQueryTimeZone = () => {
 AnsaRelatedCtrl.$inject = ['$scope', 'api', 'storage', 'Keys'];
 export default function AnsaRelatedCtrl($scope, api, storage, Keys) {
     const search = () => {
-        if (!this.query) {
+        const trimmedQuery = (this.query || '').trim();
+
+        if (!trimmedQuery) {
             this.items = [];
             this.searched = false;
             return;
@@ -26,7 +28,7 @@ export default function AnsaRelatedCtrl($scope, api, storage, Keys) {
             bool: {
                 must: [
                     {term: {type: this.activeFilter}},
-                    {query_string: {query: this.query, lenient: true, default_operator: 'AND'}},
+                    {query_string: {query: trimmedQuery, lenient: true, default_operator: 'AND'}},
                 ],
                 must_not: [{term: {item_id: $scope.item._id}}],
             },

--- a/client/ansa/widgets/ansa-related-widget.html
+++ b/client/ansa/widgets/ansa-related-widget.html
@@ -61,7 +61,8 @@
                     <div class="panel-info__icon">
                         <i class="big-icon--info"></i>
                     </div>
-                    <h3 class="panel-info__heading" translate>Not found.</h3>
+                    <h3 class="panel-info__heading" ng-if="!related.searched" translate>Search for the related content.</h3>
+                    <h3 class="panel-info__heading" ng-if="related.searched" translate>Not found.</h3>
                 </div>
             </li>
         </ul>
@@ -70,7 +71,7 @@
                 ng-click="related.filter('text')"
                 ng-class="{'toggle-button--active': related.activeFilter == 'text'}" sd-tooltip="{{ :: 'Text' | translate}}" flow="down">
                 <i class="toggle-button__icon filetype-icon-text"></i>
-                
+
             </button>
             <button class="toggle-button"
                 ng-click="related.filter('picture')"


### PR DESCRIPTION
### Expected behavior
When the widget is invoked, it doesn't search automatically. Instead of the message saying _Not found._ the message _Search for the related content._ is shown. Manual search using the search field should work as usual.

### Changes
- `AnsaRelatedCtrl.js` - dropped the `refreshAnalysis` import and call (no more `POST` to `/api/analysis`), removed the now-unused `$rootScope` injection and `isEmpty` import, removed the auto `search()` on load, and stripped the entity-based query branch (`persons/organizations/iptcCodes`) since manual text search was already its own path. `search()` now early-returns when there's no query, keeping the empty state stable. Added a searched flag to distinguish "not searched yet" from "searched, no results."
- `ansa-related-widget.html` - split the empty-state heading: shows _Search for the related content._ before any search and _Not found._ after a search returns nothing.

Filter buttons still call `search()`, but it no-ops without a query, so clicking them on widget load won't trigger a network request either. Manual search via the input + Enter behaves exactly as before.

Fixes [SDANSA-587](https://sofab.atlassian.net/browse/SDANSA-587)

[SDANSA-587]: https://sofab.atlassian.net/browse/SDANSA-587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ