### PR TITLE
[SDANSA-584] Fix toolbar line count to match in-editor count

### DIFF
--- a/client/extensions/lineCountInAuthoringHeader/src/line-count-toolbar-widget.tsx
+++ b/client/extensions/lineCountInAuthoringHeader/src/line-count-toolbar-widget.tsx
@@ -2,19 +2,31 @@ import * as React from 'react';
 
 import {IArticle, ISuperdesk} from 'superdesk-api';
 
+// body_html is lossy: editor3StateToHtml trims empty paragraphs from both ends.
+// Read DraftJS blocks from fields_meta to preserve leading empty lines.
+function getPlainText(entity: IArticle, stripHtmlTags: (html: string) => string): string | null {
+    const blocks = entity.fields_meta?.body_html?.draftjsState?.[0]?.blocks;
+
+    if (blocks != null) {
+        return blocks.map((b: {text: string}) => b.text).join('\n');
+    }
+
+    return entity.body_html != null ? stripHtmlTags(entity.body_html) : null;
+}
+
 export function getLineCountToolbarWidget(superdesk: ISuperdesk) {
     const {gettext, gettextPlural} = superdesk.localization;
     const {getLinesCount, stripHtmlTags} = superdesk.utilities;
 
     return class LineCountToolbarWidget extends React.PureComponent<{entity: IArticle}> {
         render() {
-            const {entity} = this.props;
+            const plainText = getPlainText(this.props.entity, stripHtmlTags);
 
-            if (entity.body_html == null) {
+            if (plainText == null) {
                 return null;
             }
 
-            const linesCount = getLinesCount(stripHtmlTags(entity.body_html));
+            const linesCount = getLinesCount(plainText);
 
             if (linesCount == null) {
                 return null;

--- a/client/index.ts
+++ b/client/index.ts
@@ -28,6 +28,7 @@ setTimeout(() => startApp(
     {
         countLines: (plainText, lineLength) =>
             plainText
+                .trimEnd()
                 .split('\n')
                 .reduce((sum, line) => sum + (line.length > 0 ? Math.ceil(line.length / lineLength) : 1), 0),
     },


### PR DESCRIPTION
### Description
Read DraftJS blocks from fields_meta instead of using stripHtmlTags(body_html), since the HTML serialization trims empty paragraphs from both ends, losing leading empty lines.
Also trim trailing whitespace in countLines so both counters consistently ignore trailing empty lines.

[SDANSA-584]

[SDANSA-584]: https://sofab.atlassian.net/browse/SDANSA-584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ