### PR TITLE
Refactor searchtext handling in set_default_search_operator

### DIFF
--- a/server/ansa/search.py
+++ b/server/ansa/search.py
@@ -134,11 +134,11 @@ def local_date(delta):
     now = utcnow()
     return utc_to_local(TZ, now + delta).strftime(DATE_FORMAT)
 
-
 def set_default_search_operator(params):
-    if params.get("searchtext") and "OR" not in params["searchtext"] and "AND" not in params["searchtext"]:
-        groups = re.split(r'(\w+|".*?")', params["searchtext"])
-        params["searchtext"] = " AND ".join([group for group in groups if bool(group) and group.strip()])
+    text = params.get("searchtext")
+    if text and not re.search(r'\b(OR|AND)\b', text, re.IGNORECASE):
+        tokens = re.findall(r'"[^"]+"|\w+(?:\'\w+)*', text)
+        params["searchtext"] = " AND ".join(tokens)
 
 
 class AnsaListCursor(ListCursor):


### PR DESCRIPTION
Modification to correctly handle the tokenisation of searches in the photo archive with particular attention paid to treating the apostrophe as a word-joiner rather than a token separator and to keep double-quoted searches for exact matches.

Also fix an issue that may occur if the logical operators AND and OR were used incorrectly in searches (if they appeared uppercase in the search text inside the query).